### PR TITLE
feat: Add support for copy clipboard over ssh

### DIFF
--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -6,3 +6,41 @@
 -- use `<leader>uf` to toggle autoformat
 -- [Disable autoformat for some buffers](https://www.lazyvim.org/configuration/tips#disable-autoformat-for-some-buffers)
 vim.g.autoformat = false
+
+-- [Unable to copy text from lazyvim running in remote ssh host to host clipboard #4602](https://github.com/LazyVim/LazyVim/discussions/4602)
+-- 参考：https://github.com/cameronr/kickstart-modular.nvim/blob/master/lua/options.lua
+-- Sync clipboard between OS and Neovim.
+--  Schedule the setting after `UiEnter` because it can increase startup-time.
+--  Remove this option if you want your OS clipboard to remain independent.
+--  See `:help 'clipboard'`
+vim.schedule(function()
+  vim.opt.clipboard:append('unnamedplus')
+
+  -- Fix "waiting for osc52 response from terminal" message
+  -- https://github.com/neovim/neovim/issues/28611
+
+  if vim.env.SSH_TTY ~= nil then
+    -- Set up clipboard for ssh
+
+    local function my_paste(_)
+      return function(_)
+        local content = vim.fn.getreg('"')
+        return vim.split(content, '\n')
+      end
+    end
+
+    vim.g.clipboard = {
+      name = 'OSC 52',
+      copy = {
+        ['+'] = require('vim.ui.clipboard.osc52').copy('+'),
+        ['*'] = require('vim.ui.clipboard.osc52').copy('*'),
+      },
+      paste = {
+        -- No OSC52 paste action since wezterm doesn't support it
+        -- Should still paste from nvim
+        ['+'] = my_paste('+'),
+        ['*'] = my_paste('*'),
+      },
+    }
+  end
+end)


### PR DESCRIPTION
配置`OSC 52`支持使用ssh复制，实际代码参考 https://github.com/cameronr/kickstart-modular.nvim/blob/master/lua/options.lua

参考：

* [Unable to copy text from lazyvim running in remote ssh host to host clipboard #4602](https://github.com/LazyVim/LazyVim/discussions/4602)
* [穿透 wsl 和 ssh, 新版本 neovim 跨设备任意复制，copy anywhere!](https://www.cnblogs.com/sxrhhh/p/18234652/neovim-copy-anywhere)
* [lemonade: 在 ssh nvim 中使用剪切板](https://blog.youguanxinqing.xyz/index.php/archives/165/)
* [nvim-osc52](https://github.com/ojroques/nvim-osc52)
* [Add support for OSC 52 (copy-to-clipboard) #5823](https://github.com/microsoft/terminal/pull/5823)
* [wsl2中实现neovim与系统的剪贴板共享](https://www.cnblogs.com/dogingate/p/17386993.html)
* [neovim clipboard support over ssh connection to headless server](https://www.reddit.com/r/neovim/comments/fcqbzd/neovim_clipboard_support_over_ssh_connection_to/)
* [[Question] remote tmux yank #4](https://github.com/ibhagwan/smartyank.nvim/issues/4)
* [In lazyvim, how can I copy content from ssh session to my local](https://www.reddit.com/r/neovim/comments/1b4h31g/in_lazyvim_how_can_i_copy_content_from_ssh/)