### PR TITLE
feat: Add suda.vim plugin

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -40,6 +40,7 @@
   "render-markdown.nvim": { "branch": "main", "commit": "0022a579ac7355966be5ade77699b88c76b6a549" },
   "rustaceanvim": { "branch": "master", "commit": "0a618c1d1c05a8059880076feccb15301da6993d" },
   "snacks.nvim": { "branch": "main", "commit": "98df370703b3c47a297988f3e55ce99628639590" },
+  "suda.vim": { "branch": "master", "commit": "9adda7d195222d4e2854efb2a88005a120296c47" },
   "todo-comments.nvim": { "branch": "main", "commit": "ae0a2afb47cf7395dc400e5dc4e05274bf4fb9e0" },
   "tokyonight.nvim": { "branch": "main", "commit": "45d22cf0e1b93476d3b6d362d720412b3d34465c" },
   "trouble.nvim": { "branch": "main", "commit": "46cf952fc115f4c2b98d4e208ed1e2dce08c9bf6" },

--- a/lua/plugins/suda.lua
+++ b/lua/plugins/suda.lua
@@ -1,0 +1,10 @@
+return {
+  {
+    -- [suda is a plugin to read or write files with sudo command](https://github.com/lambdalisue/vim-suda)
+    "lambdalisue/suda.vim",
+    init = function()
+      -- 自动读写需要的使用sudo的文件 https://github.com/lambdalisue/vim-suda#smart-edit
+      vim.g.suda_smart_edit = 1
+    end,
+  },
+}


### PR DESCRIPTION
sudo 支持使用sudo读写文件，参考https://github.com/lambdalisue/vim-suda

如何在neovim插件中使用全局变量？应该在`lua/plugins/suda.lua`中的init fn中添加全局变量

参考：

* 在neovim中访问全局变量`:lua= vim.g.some_var`[Accessing list of global/plugin variables](https://www.reddit.com/r/neovim/comments/18crz9r/accessing_list_of_globalplugin_variables/)
* [Loving lazyvim but am confused about plugins](https://www.reddit.com/r/neovim/comments/1d3vlfg/loving_lazyvim_but_am_confused_about_plugins/)
* [lazy.vim plugin Examples](https://lazy.folke.io/spec/examples)
* [How to set keymap for Sudawrite? #3049](https://github.com/LazyVim/LazyVim/discussions/3049)
