### PR TITLE
feat: Add pwsh as default shell instead of cmd.exe on win

### DIFF
--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -44,3 +44,18 @@ vim.schedule(function()
     }
   end
 end)
+
+-- 在win上配置默认使用pwsh
+-- 参考: https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/config/options.lua
+if jit.os == 'Windows' then
+  local win_sh = nil
+  if vim.fn.executable("pwsh") then
+    win_sh = "pwsh"
+  elseif vim.fn.executable("powershell") then
+    win_sh = "powershell"
+  end
+  if win_sh then
+    LazyVim.terminal.setup(win_sh)
+  end
+end
+

--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -14,7 +14,7 @@ vim.g.autoformat = false
 --  Remove this option if you want your OS clipboard to remain independent.
 --  See `:help 'clipboard'`
 vim.schedule(function()
-  vim.opt.clipboard:append('unnamedplus')
+  vim.opt.clipboard:append("unnamedplus")
 
   -- Fix "waiting for osc52 response from terminal" message
   -- https://github.com/neovim/neovim/issues/28611
@@ -25,21 +25,21 @@ vim.schedule(function()
     local function my_paste(_)
       return function(_)
         local content = vim.fn.getreg('"')
-        return vim.split(content, '\n')
+        return vim.split(content, "\n")
       end
     end
 
     vim.g.clipboard = {
-      name = 'OSC 52',
+      name = "OSC 52",
       copy = {
-        ['+'] = require('vim.ui.clipboard.osc52').copy('+'),
-        ['*'] = require('vim.ui.clipboard.osc52').copy('*'),
+        ["+"] = require("vim.ui.clipboard.osc52").copy("+"),
+        ["*"] = require("vim.ui.clipboard.osc52").copy("*"),
       },
       paste = {
         -- No OSC52 paste action since wezterm doesn't support it
         -- Should still paste from nvim
-        ['+'] = my_paste('+'),
-        ['*'] = my_paste('*'),
+        ["+"] = my_paste("+"),
+        ["*"] = my_paste("*"),
       },
     }
   end
@@ -47,7 +47,7 @@ end)
 
 -- 在win上配置默认使用pwsh
 -- 参考: https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/config/options.lua
-if jit.os == 'Windows' then
+if jit.os == "Windows" then
   local win_sh = nil
   if vim.fn.executable("pwsh") then
     win_sh = "pwsh"
@@ -58,4 +58,3 @@ if jit.os == 'Windows' then
     LazyVim.terminal.setup(win_sh)
   end
 end
-


### PR DESCRIPTION
windows默认终端shell为cmd.exe，现在修改为pwsh或powershell。参考默认配置https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/config/options.lua

参考：

* [feature: Change the default terminal in Windows from cmd to Windows Powershell #2151](https://github.com/LazyVim/LazyVim/issues/2151)
* [Windows change default from pwsh to nushell #3694](https://github.com/LazyVim/LazyVim/discussions/3694)