### PR TITLE
fix: memory bloat and lag in Neovim after prolonged operation

### DIFF
--- a/lua/config/lazy.lua
+++ b/lua/config/lazy.lua
@@ -27,6 +27,9 @@ require("lazy").setup({
     -- add LazyVim and import its plugins
     { "LazyVim/LazyVim", import = "lazyvim.plugins" },
     -- extras
+    -- NOTE: 这里只加载所有系统通用插件，由于 vim.fn.executable 在部分系统如
+    -- windows/wsl2 中非常耗时，需要手动在 `:LazyExtras` 中启用或在
+    -- lazyvim.json 中添加
     { import = "lazyvim.plugins.extras.coding.mini-surround" },
     { import = "lazyvim.plugins.extras.coding.yanky" },
     { import = "lazyvim.plugins.extras.editor.dial" },
@@ -45,9 +48,10 @@ require("lazy").setup({
     { import = "lazyvim.plugins.extras.lang.yaml" },
     { import = "lazyvim.plugins.extras.lsp.neoconf" },
     { import = "lazyvim.plugins.extras.test.core" },
-    { import = "lazyvim.plugins.extras.ui.mini-indentscope" },
+    -- Neovim Lua plugin to animate common Neovim actions.
+    -- https://github.com/nvim-mini/mini.animate
     { import = "lazyvim.plugins.extras.ui.mini-animate" },
-    { import = "lazyvim.plugins.extras.ui.smear-cursor" },
+    -- 用于显示当前可见缓冲区内容的上下文，通常是在最上面显示当前光标所在的函数
     { import = "lazyvim.plugins.extras.ui.treesitter-context" },
     { import = "lazyvim.plugins.extras.util.dot" },
     { import = "lazyvim.plugins.extras.util.mini-hipatterns" },

--- a/lua/plugins/editor/buf.lua
+++ b/lua/plugins/editor/buf.lua
@@ -1,5 +1,22 @@
 ---@type LazySpec
--- [sleuth.vim: Heuristically set buffer options](https://github.com/tpope/vim-sleuth)
 return {
-  "tpope/vim-sleuth",
+  {
+    -- [sleuth.vim: Heuristically set buffer options](https://github.com/tpope/vim-sleuth)
+    "tpope/vim-sleuth",
+  },
+  {
+    -- Send buffers into early retirement by automatically closing them
+    -- after x minutes of inactivity.
+    -- https://github.com/chrisgrieser/nvim-early-retirement
+    "chrisgrieser/nvim-early-retirement",
+    event = "VeryLazy",
+    ---@module 'early-retirement'
+    ---@type opts
+    ---@diagnostic disable-next-line: missing-fields
+    opts = {
+      retirementAgeMins = 15,
+      notificationOnAutoClose = true,
+      minimumBufferNum = 10,
+    },
+  },
 }


### PR DESCRIPTION
## 问题现象

我发现在使用 neovim 操作一段时间后通常是几小时，UI 会有卡顿感，特别是 blink.cmp
补全时常常会等待 1s 左右响应，但在刚启动时是很快的，慢慢的就变这样了，
而且也不只是 blink.cmp，在 c-f 等翻页操作也有卡顿感，但没有补全这么明显，
我尝试注释了所有的当前 plugins，只启用 import lazyvim，
但还是操作一段时间后还是会有明显的卡顿感，这里也有类似的讨论
[Poor performance after a few hours](https://github.com/LazyVim/LazyVim/discussions/326)

- UI 出现明显卡顿感，补全 (blink.cmp) 响应延迟约 1s
- `Ctrl-f` 翻页等常规操作也有卡顿
- **进程 RSS 膨胀到 2.7GB 以上**,且无法通过关闭缓冲区回收
- 重启 Neovim 后恢复，但数小时后又复发

---

## 排查过程 (非常曲折)

> 每轮均列出**实际使用的测量命令**,可直接复制复用。

### 第一轮：怀疑 LSP 日志与补全插件

**测量命令：**

```bash
# LSP 日志大小与内容分布
du -sh ~/.local/state/nvim/lsp.log
grep -c "harper" ~/.local/state/nvim/lsp.log
grep "harper-ls" ~/.local/state/nvim/lsp.log | tail -5

# 统计各 LSP 客户端的 stderr 输出量(找刷屏者)
awk -F'"' '/stderr/{print $4}' ~/.local/state/nvim/lsp.log | sort | uniq -c | sort -rn | head
```

```vim
" 当前 nvim 内存/CPU
" (bash) ps -o pid,etime,time,%cpu,%mem,rss,vsz,cmd -p <nvim_pid>
```

**结果与结论：**

1. `lsp.log` 膨胀到 11MB，其中 harper-ls 疯狂输出
   `"Settings must be an object"`(harper-ls 已知 bug,#3151/#3156)。
   → 禁用 harper-ls、设置日志级别、定期清理，**无效**。
2. 怀疑 blink.cmp buffer source(官方 benchmark 显示大量 buffer 下
   sync 解析可达数百 ms)。
   → 限制 `max_sync_buffer_size` / `max_total_buffer_size`,**无效**。
3. 怀疑 noice.nvim 消息累积 (issue #1223 描述 LSP progress 消息
   处理开销)。
   → 完全禁用 noice,**无效**(且当前会话 noice 根本没加载，仍卡)。

### 第二轮：排除本地插件

**测量命令：**

```lua
-- 注释掉全部 lua/plugins/ 本地配置，只保留 LazyVim 默认
-- 观察数小时，卡顿依旧 → 问题在 LazyVim 默认组件或环境层面
```

**结论：** 与本地自定义插件无关。注意:smear-cursor 是 LazyVim
的 `extras/ui/smear-cursor` 默认组件，不在 `lua/plugins/` 下，
因此这一轮它依然启用——这是后续困惑的伏笔。

### 第三轮：定位到内存膨胀 (关键数据)

**测量命令 (在卡顿会话中执行):**

```vim
" Lua 内存(GC 前)
:lua print("lua mem KB: " .. collectgarbage("count"))

" 强制 GC 后剩余(区分"可回收垃圾" vs "泄漏强引用")
:lua collectgarbage("collect"); print("after gc KB: " .. collectgarbage("count"))

" full GC 实际耗时(卡顿的直接证据)
:lua local t=vim.loop.hrtime(); collectgarbage("collect"); print("full GC: " .. string.format("%.0f", (vim.loop.hrtime()-t)/1e6) .. " ms")

" 事件循环健康度(排除事件循环阻塞)
:lua local t=vim.loop.hrtime(); for i=1,1000 do vim.schedule(function() end) end; print("sched 1000: " .. string.format("%.0f", (vim.loop.hrtime()-t)/1e6) .. " ms")

" 进程内存(bash)
" ps -o pid,etime,time,%cpu,%mem,rss,vsz,cmd -p <pid>
" uptime
```

**测量结果：**

| 指标                      | 数值      | 说明                        |
| ------------------------- | --------- | --------------------------- |
| Lua 内存 (GC 前)          | 270MB     | 对象大量累积                |
| Lua 内存 (GC 后)          | 117MB     | 强引用被持有，非可回收垃圾  |
| **full GC 耗时**          | **468ms** | 单次 GC 停顿冻结 UI 约 0.5s |
| 事件循环 (sched ×1000)    | 2ms       | 事件循环本身正常            |
| treesitter parser         | 仅 8 个   | 排除 treesitter             |
| undo 历史                 | 0 条      | 排除 undo                   |
| blink/yanky/gitsigns 缓存 | 全部为 0  | 排除这些缓存                |

**结论：** 卡顿机制 = Lua 堆膨胀 → GC 停顿 468ms → UI 冻结。
但 117MB 强引用 + RSS 2.7GB 的来源一度无法定位——
Lua 侧各插件缓存均为空。

**排除用测量命令 (已逐一执行):**

```vim
" treesitter parser 数量
:lua local n=0; for _,b in ipairs(vim.api.nvim_list_bufs()) do local ok,p=pcall(vim.treesitter.get_parser,b); if ok and p then n=n+1 end end; print("parsers: "..n)

" buffer 文本总量(排除内容占内存)
:lua local s=0; for _,b in ipairs(vim.api.nvim_list_bufs()) do s=s+vim.fn.strlen(table.concat(vim.api.nvim_buf_get_lines(b,0,-1,false),"")) end; print("total chars: "..s)

" blink buffer cache
:lua local ok, bc = pcall(require, "blink.cmp.sources.buffer.cache"); if ok then local n=0; for _ in pairs(bc._cache or {}) do n=n+1 end; print("blink buffer cache: "..n) else print("not loaded") end

" yanky 历史
:lua local ok, y = pcall(require, "yanky.history"); if ok then print("yanky history: "..vim.tbl_count(y._history or {})) else print("not loaded") end

" gitsigns 缓存
:lua local ok, gs = pcall(require, "gitsigns"); if ok then local n=0; for _ in pairs(gs.bcache or gs.cache or {}) do n=n+1 end; print("gitsigns cache: "..n) else print("not loaded") end

" noice 消息历史(若 noice 加载)
:lua print("noice history: " .. vim.tbl_count(require("noice.message.manager")._history))

" autocmd 总数与分布
:lua print("autocmds: " .. #vim.api.nvim_get_autocmds({}))

" 已加载插件清单
:lua local t={}; for name,_ in pairs(package.loaded) do if name:find("^[a-z]") and not name:find("^vim") then table.insert(t,name) end end; print(table.concat(t,"\n"))
```

### 第四轮：决定性发现 (buffer 泄漏)

**测量命令：**

```vim
" 列出全部 buffer:编号、类型、listed、名称
:lua for _,b in ipairs(vim.api.nvim_list_bufs()) do print(b.." | type="..(vim.bo[b].buftype or "?").." | listed="..tostring(vim.bo[b].buflisted).." | "..vim.api.nvim_buf_get_name(b)) end

" 只看 nofile 类型 + filetype + 局部变量(识别创建者)
:lua for _,b in ipairs(vim.api.nvim_list_bufs()) do if vim.bo[b].buftype=="nofile" then print(b.." | ft="..(vim.bo[b].filetype or "?").." | "..vim.inspect(vim.b[b])) end end

" 各 buffer 行数(判断内容量)
:lua for _,b in ipairs(vim.api.nvim_list_bufs()) do if vim.bo[b].filetype=="smear-cursor" then print(b.." lines="..vim.api.nvim_buf_line_count(b)) end end

" 监视新 buffer 的创建(找出创建者,最强手段)
:lua vim.api.nvim_create_autocmd({"BufNew","BufAdd"}, {callback=function(a) vim.schedule(function() if vim.bo[a.buf] and vim.bo[a.buf].buftype=="nofile" then print("CREATED: "..a.buf.." ft="..(vim.bo[a.buf].filetype or "?")) end end) end})
" 然后正常操作几秒(滚动/补全/保存),观察打印
```

**测量结果：**

```
2823 | type= | listed=true  |
3179~3213 | type=nofile | listed=false | (34 个)
3221 | type=nofile | ft=blink-cmp-menu |
3270 | type=nofile | ft=snacks_notif |
3271~3272 | type=nofile | ft=noice |
3274~3282, 3322~3326 | type=nofile | ft=smear-cursor | (持续增长)
```

关键特征：

- **buffer 编号已达 3300+**,而正常会话通常只有几十——
  说明有东西在**反复创建新 buffer**。
- 大量 `ft=smear-cursor` 的 `nofile` buffer，每个仅 1 行，
  但**数量持续增长**(观察期间从 34 个涨到 46 个)。
- 这些 buffer **无法用 `nvim_buf_delete(force=true)` 删除**
  (报 "buffer is in use"——被隐藏窗口引用)。

**清理 (缓解，非根治):**

```vim
" 先关窗口再删 buffer
:lua for _,w in ipairs(vim.api.nvim_list_wins()) do local b=vim.api.nvim_win_get_buf(w); if vim.bo[b].filetype=="smear-cursor" then pcall(vim.api.nvim_win_close,w,true) end end
:lua for _,b in ipairs(vim.api.nvim_list_bufs()) do if vim.bo[b].filetype=="smear-cursor" then pcall(vim.api.nvim_buf_delete,b,{force=true}) end end
```

---

## 根因:smear-cursor.nvim 泄漏 buffer/window

源码确认 (`smear-cursor.nvim` v0.6.0):

**`lua/smear_cursor/config.lua:65`**

```lua
M.max_kept_windows = 50
```

**`lua/smear_cursor/draw.lua:201-218`** — 每次动画帧在无可用窗口时创建新 buffer+window:

```lua
local buffer_id = vim.api.nvim_create_buf(false, true)
local window_id = vim.api.nvim_open_win(buffer_id, false, {
  relative = "editor", ... style = "minimal", noautocmd = true, ...
})
set_buffer_options(buffer_id, {
  buftype = "nofile", filetype = "smear-cursor",
  bufhidden = "wipe", swapfile = false,
})
```

**`lua/smear_cursor/draw.lua:242-267`** — `clear()` 只隐藏、不删除前 50 个窗口：

```lua
M.clear = function()
  for tab, tab_windows in pairs(all_tab_windows) do
    -- Hide windows without deleting them
    for i = 1, math.min(tab_windows.active, config.max_kept_windows) do
      ...
      vim.api.nvim_win_set_config(wb.window_id, { hide = true })  -- 仅隐藏！
    end
    ...
  end
end
```

### 泄漏机制

1. 每次光标移动/滚动触发动画，`get_window()` 按 `(row, col, zindex)`
   查找可复用窗口;找不到就 `nvim_create_buf + nvim_open_win`。
2. 动画结束时 `clear()` **只把窗口 `hide=true`,并不关闭窗口、
   也不删除 buffer**(即使 `bufhidden = "wipe"` 也不会触发，
   因为 buffer 仍被窗口持有)。
3. 每个 tab 最多保留 `max_kept_windows = 50` 个窗口/buffer;
   但**多个 tab 页 × 50**,且动画频率高时窗口数量持续爬升。
4. 累积结果：数千次 buffer 创建 → C 侧 buffer/extmark/窗口数据
   碎片化膨胀 → glibc malloc 不归还 OS → **RSS 膨胀到 2.7GB**;
   同时 Lua 堆受连带影响 (270MB)→ GC 停顿 468ms → 卡顿。

### 为什么"只启用 LazyVim 也复现"

smear-cursor 是 LazyVim 的 `extras/ui/smear-cursor` 默认组件，
不在用户的 `lua/plugins/` 下。因此注释掉全部本地插件后
**它依然启用**,卡顿依然存在——这解释了此前多轮"禁用插件无效"
的困惑。

---

## 复现步骤

1. 配置 LazyVim + `lazyvim.plugins.extras.ui.smear-cursor` extra。
2. 启动 nvim，在代码文件中持续移动光标/滚动 (触发动画) 数小时。
3. 观察：`vim.api.nvim_list_bufs()` 中出现大量 `ft=smear-cursor`
   nofile buffer，编号持续增长;进程 RSS 持续膨胀;UI 卡顿。

## 影响

- 长时间编辑会话内存无限增长 (实测 2.7GB+)
- GC 停顿导致 UI 卡顿、补全响应延迟
- buffer 表被垃圾 buffer 污染 (无法删除，影响 buffer 切换/列表)

## 修复

1. 禁用该插件

   ```lua
   -- lua/config/lazy.lua
   -- { import = "lazyvim.plugins.extras.ui.smear-cursor" },
   ```
2. 避免打开过多 buffer 不关闭，添加插件
[nvim-early-retirement](https://github.com/chrisgrieser/nvim-early-retirement)

## 验证数据

- 出现 46+ 个 `ft=smear-cursor` nofile buffer(每 buffer 仅 1 行)
- buffer 编号:2823 → 3326(观察期内持续增长)
- RSS:2,860,544 KB(2.7GB),VSZ 3.2GB
- full GC:468ms;Lua 堆:270MB(GC 后 117MB)
- 禁用 smear-cursor 后 (待验证):buffer 编号应停止增长

## 排查命令速查表

| 目的           | 命令                                                                                                                                        |
| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
| Lua 内存       | `:lua print(collectgarbage("count"))`                                                                                                       |
| GC 后可回收量  | `:lua collectgarbage("collect"); print(collectgarbage("count"))`                                                                            |
| full GC 耗时   | `:lua local t=vim.loop.hrtime(); collectgarbage("collect"); print((vim.loop.hrtime()-t)/1e6)`                                               |
| 进程 RSS       | `ps -o pid,rss,vsz,%cpu,etime,cmd -p <pid>`                                                                                                 |
| buffer 清单    | `:lua for _,b in ipairs(vim.api.nvim_list_bufs()) do print(b.." \| "..(vim.bo[b].buftype or "?").." \| "..(vim.bo[b].filetype or "?")) end` |
| 监视新 buffer  | 见第四轮 autocmd 命令                                                                                                                       |
| LSP 日志刷屏源 | `awk -F'"' '/stderr/{print $4}' ~/.local/state/nvim/lsp.log \| sort \| uniq -c \| sort -rn`                                                 |

