### PR TITLE
feat: Improved notification time accuracy for picker,notifier of snacks

### DIFF
--- a/lua/plugins/editor/picker.lua
+++ b/lua/plugins/editor/picker.lua
@@ -34,6 +34,35 @@ return {
                 },
               },
             },
+            -- 默认实现见 snacks.nvim/lua/snacks/picker/format.lua:723，
+            -- 只有时间行被改动："%R"→"%T"、宽度 5→8，其余完全照搬
+            ---@see snacks.picker.formatters.notification
+            format = function(item, picker)
+              local a = Snacks.picker.util.align
+              ---@type snacks.picker.Highlight[]
+              local ret = {}
+              ---@type snacks.notifier.Notif
+              local notif = item.item
+              -- added 为纳秒精度浮点秒，手动拆分秒与毫秒（%f 不被 LuaJIT 支持）
+              local sec = math.floor(notif.added)
+              local ms = math.floor((notif.added % 1) * 1000 + 0.5) -- 四舍五入避免浮点误差
+              local time = os.date("%T", sec) .. string.format(".%03d", ms)
+              ret[#ret + 1] = { a(time, #time), "SnacksPickerTime" }
+              ret[#ret + 1] = { " " }
+              if item.severity then
+                vim.list_extend(
+                  ret,
+                  Snacks.picker.format.severity(item, picker)
+                )
+              end
+              ret[#ret + 1] = { " " }
+              ret[#ret + 1] =
+                { a(notif.title or "", 15), "SnacksNotifierHistoryTitle" }
+              ret[#ret + 1] = { " " }
+              ret[#ret + 1] = { notif.msg, "SnacksPickerNotificationMessage" }
+              Snacks.picker.highlight.markdown(ret)
+              return ret
+            end,
           },
         },
       },

--- a/lua/plugins/editor/ui.lua
+++ b/lua/plugins/editor/ui.lua
@@ -2,6 +2,20 @@
 ---@type LazySpec
 return {
   {
+    "snacks.nvim",
+    optional = true,
+    ---@type snacks.Config
+    opts = {
+      notifier = {
+        ---@type snacks.notifier.style
+        style = "compact",
+        -- 默认 %R： 24小时制（时:分）
+        -- %T： 24小时制（时:分:秒）
+        date_format = "%T",
+      },
+    },
+  },
+  {
     "nvim-mini/mini.animate",
     optional = true,
     -- NOTE: 在 vscode 中禁用避免滚动出问题，使用 `vscode=true` 无效


### PR DESCRIPTION
## 背景

Snacks 通知的时间显示默认仅到分钟，无法区分同一分钟内先后到达的通知：

- picker `notifications` 源在 `snacks/picker/format.lua:727` 硬编码
  `os.date("%R", notif.added)`，且对齐宽度固定为 5

https://github.com/folke/snacks.nvim/blob/882c996cf28183f4d63640de0b4c02ec886d01f2/lua/snacks/picker/format.lua#L727


- notifier 的 `date_format` 默认 `"%R"`（`notifier.lua:137`），history/fancy
  两种渲染均直接 `os.date(format, added)`，配置层面无法表达毫秒
  （LuaJIT 不支持 `%f` 占位符，已实测验证）

https://github.com/folke/snacks.nvim/blob/882c996cf28183f4d63640de0b4c02ec886d01f2/lua/snacks/notifier.lua#L137

## 改动

**`lua/plugins/editor/picker.lua`** — 覆盖 `notifications` 源 `format` 函数，
其余逻辑照搬默认实现（`snacks/picker/format.lua:723`）：
- 时间显示为 `HH:MM:SS.mmm`（毫秒 3 位）
- `notif.added` 为纳秒精度浮点秒，手动拆分秒与毫秒，四舍五入避免浮点误差

**`lua/plugins/editor/ui.lua`** — 新增 `snacks.nvim` optional 配置块：
- `date_format = "%T"`（`HH:MM:SS`），覆盖默认 `%R`
- 显式声明 `style = "compact"`

## 验证

- 重启 nvim 后 `<leader>n` 打开通知 picker，确认时间列显示到毫秒且对齐正常
- `:Snacks.notifier.show_history()` 确认 history 窗口时间到秒
- `stylua lua/plugins/editor/` 已格式化

## 备注

- picker 中 `a(time, #time)` 宽度即自身长度，等价于不填充，仅为保持与默认
  实现一致的调用形式
- notifier 时间在插件更新后不会被覆盖（纯配置）；picker 覆盖同为配置层，
  均不修改插件源码