### PR TITLE
feat(autotheme): Respect modified background option on startup

### DIFF
--- a/local_plugins/autotheme/lua/autotheme/init.lua
+++ b/local_plugins/autotheme/lua/autotheme/init.lua
@@ -121,7 +121,10 @@ function Persisted.save(path, o)
     return w_err
   end
   if w_bytes ~= #json_str then
-    return "invalid write byte size=" .. w_bytes .. " for content size=" .. #json_str
+    return "invalid write byte size="
+      .. w_bytes
+      .. " for content size="
+      .. #json_str
   end
   return nil
 end
@@ -155,7 +158,8 @@ function ThemeData.new(path)
 
   nio.scheduler()
   ---@type autotheme.BackgroundThemeData
-  local default = { background = vim.o.background or "dark", dark = {}, light = {} }
+  local default =
+    { background = vim.o.background or "dark", dark = {}, light = {} }
   ---@type autotheme.BackgroundThemeData
   obj = vim.tbl_extend("keep", obj, default)
   return setmetatable(obj, { __index = ThemeData }), nil
@@ -268,7 +272,10 @@ function AutoTheme:set_theme(bg)
         end
 
         -- 如果主题未修改 或 bg 未修改且在 set_theme 调用中时退出
-        if vim.g.colors_name == name or (self._background_lock and vim.o.background ~= background) then
+        if
+          vim.g.colors_name == name
+          or (self._background_lock and vim.o.background ~= background)
+        then
           return false
         end
 
@@ -279,7 +286,9 @@ function AutoTheme:set_theme(bg)
         local ok, res = pcall(vim.cmd.colorscheme, name)
         self._background_lock = false
         if not ok then
-          log.error("Failed to set theme " .. name .. " with error: " .. (res or ""))
+          log.error(
+            "Failed to set theme " .. name .. " with error: " .. (res or "")
+          )
           return false
         end
         return true
@@ -297,7 +306,8 @@ local _autotheme_fut = nil
 
 function M.setup(_)
   _autotheme_fut = nio.control.future()
-  local augroup = vim.api.nvim_create_augroup("MyAutoThemeGroup", { clear = true })
+  local augroup =
+    vim.api.nvim_create_augroup("MyAutoThemeGroup", { clear = true })
   vim.api.nvim_create_autocmd("VimEnter", {
     pattern = "*",
     group = augroup,
@@ -305,14 +315,22 @@ function M.setup(_)
       nio.run(function()
         -- NOTE: 在启动时 yield 到主线程以使用 vim.fn 避免 read file 死循环
         nio.scheduler()
-        local filepath = vim.fs.joinpath(vim.fn.stdpath("state"), ".autotheme.json")
+        local filepath =
+          vim.fs.joinpath(vim.fn.stdpath("state"), ".autotheme.json")
         local t, t_err = AutoTheme.new(filepath, augroup)
         if not t then
           log.error("Failed to init autotheme: " .. t_err)
           return
         end
+
+        -- background 默认值为 dark，如果检测终端支持 OSC 11 会自动设置导致
+        -- was_set=true
+        local bg_info = vim.api.nvim_get_option_info2("background", {})
+        -- 默认 nil 让内部使用上次的 bg
+        -- 如果 background 是被修改过的则使用其值
+        local bg = bg_info.was_set and vim.o.background or nil
         -- 在启动时优先 set_theme，外部主动的 set_theme 后置生效
-        t:set_theme()
+        t:set_theme(bg)
         _autotheme_fut.set(t)
       end)
     end,


### PR DESCRIPTION
## 背景

nvim 的 `'background'` 默认值为 `dark`，`was_set=false`。启动时 nvim 会通过 OSC 11 + DSR 查询终端背景色（`runtime/lua/vim/_core/defaults.lua:915`），收到响应后按亮度设置 `'background'`，此时 `was_set=true`（来源为 Lua，`last_set_sid=-8`）。参考 #36 

autotheme 在 `VimEnter` 时恢复上次持久化的主题（`.autotheme.json` 中记录的 `background` 与对应主题名）。

## 问题

本次启动时若 OSC 11 已检测到终端实际明暗（例如检测为 `light`），autotheme 仍会用上次持久化的 `bg`（例如 `dark`）恢复主题；且 `set_theme` 内部会执行 `vim.o.background = background`，把 OSC 11 的检测结果覆盖掉——导致恢复的主题与终端实际明暗不一致。

## 修复

`M.setup` 的 `VimEnter` 回调中，先读取 `vim.api.nvim_get_option_info2("background", {}).was_set`：

- `was_set=true`（background 已被 OSC 11 检测或配置显式设置）→ 使用当前 `vim.o.background` 作为恢复依据
- `was_set=false`（保持默认，未被设置）→ 维持原逻辑，沿用上次持久化的 `bg`

并保留兜底链路：即使 `VimEnter` 时 OSC 11 响应尚未到达，后续响应到达并设置 `background` 时，会触发已有的 `OptionSet background` autocmd 自动切换主题。

## 验证

- 静态确认：`nvim_get_option_info2` 返回 `was_set` 字段，语义为"是否被显式设置过"（实测默认 `false`）
- 环境说明：当前环境为 WSL + Windows Terminal + tmux 3.5a，tmux 3.5a 对 OSC 11 查询可能不应答（实测无 `TermResponse`），此时 `was_set=false`，行为与旧版一致；修复生效场景为 OSC 11 应答正常（原生终端 / kitty / Ghostty 或 tmux 缓存存在）
- 建议合并前手动验证：在支持 OSC 11 应答的终端中，`light` 主题下启动 nvim，确认恢复 `light` 主题而非上次的 `dark`

## 行为变化（有意为之）

若 `was_set=true` 但持久化数据中没有对应 `bg` 的历史主题，启动时不再恢复旧主题（输出 `Not found hist theme` 警告），保持当前默认主题——优先跟随终端实际明暗。
