### PR TITLE
fix: reload bufferline highlights on first colorscheme switch

### DIFF
--- a/lua/plugins/editor/colorscheme.lua
+++ b/lua/plugins/editor/colorscheme.lua
@@ -35,21 +35,64 @@ return {
       },
     },
   },
-  -- {
-  --   "LazyVim/LazyVim",
-  --   optional = true,
-  --   ---@type LazyVimConfig
-  --   opts = {
-  --     -- 在启动后首次执行 `colorscheme catppuccin-latte` 等主题切换后 bufferline
-  --     -- 颜色未改变，再次 colorscheme 切换才会生效。这可能是 tokyonight,catppuccin
-  --     -- 需要专门适配，所以这里不会覆盖原 lazyvim 的主题配置
-  --     --- FIXME: [Bug]: highlights are not fully reloaded on ColorScheme autocmd
-  --     --- https://github.com/akinsho/bufferline.nvim/issues/1030
-  --     -- colorscheme = function()
-  --     --   require("tokyonight").load()
-  --     -- end,
-  --   },
-  -- },
+  {
+    "LazyVim/LazyVim",
+    optional = true,
+    ---@type LazyVimConfig
+    opts = {
+      -- 在启动后首次执行 `colorscheme catppuccin-latte` 等主题切换后 bufferline
+      -- 颜色未改变，再次 colorscheme 切换才会生效。这可能是 tokyonight,catppuccin
+      -- 需要专门适配，所以这里不会覆盖原 lazyvim 的主题配置
+      --- FIXME: [Bug]: highlights are not fully reloaded on ColorScheme autocmd
+      --- https://github.com/akinsho/bufferline.nvim/issues/1030
+      colorscheme = function()
+        -- 移除 lazyvim 的主题配置，让 autotheme,auto-dark-mode 配置
+        -- require("tokyonight").load()
+
+        -- 在首次切换主题时检查，如果是 catppuccin 类型的主题则再次切换修复
+        -- bufferline 的高亮问题
+        vim.api.nvim_create_autocmd("ColorScheme", {
+          -- 只执行一次
+          once = true,
+          callback = function(args)
+            -- NOTE: 如果有其它主题也无法在启动时首次切换主题无法设置 bufferline
+            -- 的高亮，可以根据需要扩展任意主题
+            if not args.match:match("^catppuccin") then
+              return
+            end
+            vim.schedule(function()
+              local ok, res = pcall(vim.cmd.colorscheme, args.match)
+              if not ok then
+                vim.notify(
+                  string.format(
+                    "failed to run `colorscheme %s` by error: %s",
+                    args.match,
+                    res
+                  ),
+                  vim.log.levels.ERROR
+                )
+              end
+            end)
+          end,
+        })
+
+        -- NOTE: ai 的解决方案
+        -- 原理：切换前组已被清除 → 主题加载后 ColorScheme 事件中 bufferline
+        -- 设置成功（组不存在）；后续切换主题自身 hi clear 兜底，清除幂等无害；
+        -- transparent.nvim 的 BufferLineFill 透明不受影响（其在
+        -- ColorScheme 事件中强制设置）。
+        -- vim.api.nvim_create_autocmd("ColorSchemePre", {
+        --   callback = function()
+        --     for _, name in
+        --       ipairs(vim.fn.getcompletion("BufferLine*", "highlight"))
+        --     do
+        --       vim.api.nvim_set_hl(0, name, {})
+        --     end
+        --   end,
+        -- })
+      end,
+    },
+  },
   {
     dir = vim.fs.joinpath(vim.fn.stdpath("config"), "local_plugins/autotheme"),
     dependencies = { "nvim-neotest/nvim-nio" },


### PR DESCRIPTION
## 问题现象

启动时未设置 colorscheme（vim.g.colors_name = nil，处于 nvim 默认 blue 主题）时，如果在 #37 中默认使用终端主题 dark/light，由于其首次执行 :colorscheme catppuccin-latte / catppuccin-mocha 切换主题后，bufferline 顶部（选中 buffer）高亮保持旧主题颜色不变，第二次切换才恢复正常。

## 调查过程（headless 实测证据）

### 复现与范围确认

- headless 下加载完整配置 + 手动加载 bufferline，切换前后读取 BufferLineBufferSelected 等组：
  - 首次 catppuccin-mocha → 高亮保持 blue 主题色 #e0e2ea/#14161b，未更新
  - 第二次 catppuccin-latte → 正确更新为 latte 色
- tokyonight 同样复现（首次 tokyonight-moon 不更新，第二次正常）→ 排除 catppuccin 特有，根因在通用机制

### 排除项

- 手动执行 hi clear 后再切换 → 首次即正常 → 确认 hi clear 是关键
- hi clear 不触发 ColorScheme 事件（autocmd 计数验证 = 0）
- catppuccin 编译缓存文件中不含任何 BufferLine* 组（strings 检索 = 0）→ 这些组完全由 bufferline 自身管理

### 根因链

1. bufferline 以 default=true 设置高亮组（themable = true 默认，config.lua:633）。:h nvim_set_hl-default 语义：目标组已存在（非默认值）时，覆盖被忽略
2. catppuccin 编译文件（lib/compiler.lua:30）与 tokyonight（theme.lua:11-13）的 hi clear 为条件执行：if vim.g.colors_name then vim.cmd("hi clear") end
3. 启动未设置主题 → colors_name = nil → 首次切换不执行 hi clear → 启动时 bufferline 设置的旧 BufferLine* 组残留
4. ColorScheme 事件中 bufferline 重算高亮并以 default=true 设置 → 组已存在 → 被 nvim 忽略 → 高亮不更新
5. 第二次切换：colors_name 已存在 → hi clear 清除全部组 → bufferline 设置成功

> 这也解释了为何 LazyVim 默认配置（启动即 require("tokyonight").load()）无此问题：启动后 colors_name 始终存在，每次切换都会执行 hi clear。

## 修复原理

在 colorscheme 函数中注册一次性（once = true）ColorScheme autocmd：首次切换且主题匹配 ^catppuccin 时，vim.schedule 中再次执行 :colorscheme <theme>。二次切换时 colors_name 已存在 → 主题脚本执行 hi clear → 旧组清除 → bufferline 的 default=true 设置成功。

设计取舍：

- 零侵入：不修改 bufferline 配置，复用主题自带的 hi clear 机制
- 仅首次切换一次性开销；once = true 保证之后不再触发
- 备选方案（ColorSchemePre 时清除 BufferLine* 组）更通用但侵入 bufferline 默认行为，已注释保留参考
- 已知边界：仅覆盖首次切换即 catppuccin 的场景；若首次切换其他主题，once autocmd 会被消耗（代码注释已说明，可按需扩展）

## 验证

- 首次 catppuccin-latte / catppuccin-mocha 切换后 bufferline 高亮正确更新（headless 实测）
- 后续 dark/light 往返切换无回归